### PR TITLE
Implement (un)follow, (un)favorite

### DIFF
--- a/lib/bloc/article/article_bloc.dart
+++ b/lib/bloc/article/article_bloc.dart
@@ -19,6 +19,8 @@ class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
     on<ArticleGetArticle>(_articleGetArticleHandler);
     on<ArticleFollowUser>(_articleFollowUserHandler);
     on<ArticleUnfollowUser>(_articleUnfollowUserHandler);
+    on<ArticleFav>(_articleFavHandler);
+    on<ArticleUnfav>(_articleUnfavHandler);
   }
 
   Future<void> _articleGetArticleHandler(
@@ -108,6 +110,78 @@ class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
         article: state.article?.copyWithAuthor(
           author: res,
         ),
+      ));
+    } on DioException catch (e) {
+      if (e.response != null) {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.response!.data.toString(),
+        ));
+      } else {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.message,
+        ));
+      }
+    } catch (e) {
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.error,
+        message: e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _articleFavHandler(
+    ArticleFav event,
+    Emitter<ArticleState> emit,
+  ) async {
+    if (state.article!.slug == null) return;
+
+    emit(state.copyWith(articleStatus: ECommonStatus.loading));
+    try {
+      var res = await articleRepository.favArticle(
+        slug: state.article!.slug!,
+      );
+
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.loaded,
+        article: res,
+      ));
+    } on DioException catch (e) {
+      if (e.response != null) {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.response!.data.toString(),
+        ));
+      } else {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.message,
+        ));
+      }
+    } catch (e) {
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.error,
+        message: e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _articleUnfavHandler(
+    ArticleUnfav event,
+    Emitter<ArticleState> emit,
+  ) async {
+    if (state.article!.slug == null) return;
+
+    emit(state.copyWith(articleStatus: ECommonStatus.loading));
+    try {
+      var res = await articleRepository.unfavArticle(
+        slug: state.article!.slug!,
+      );
+
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.loaded,
+        article: res,
       ));
     } on DioException catch (e) {
       if (e.response != null) {

--- a/lib/bloc/article/article_bloc.dart
+++ b/lib/bloc/article/article_bloc.dart
@@ -4,16 +4,21 @@ import 'package:real_world/bloc/article/article_event.dart';
 import 'package:real_world/bloc/article/article_state.dart';
 import 'package:real_world/common/enum/common_status_enum.dart';
 import 'package:real_world/repository/article_repository.dart';
+import 'package:real_world/repository/profile_repository.dart';
 
 class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
   final String slug;
   final ArticleRepository articleRepository;
+  final ProfileRepository profileRepository;
 
   ArticleBloc({
     required this.slug,
     required this.articleRepository,
+    required this.profileRepository,
   }) : super(const ArticleState()) {
     on<ArticleGetArticle>(_articleGetArticleHandler);
+    on<ArticleFollowUser>(_articleFollowUserHandler);
+    on<ArticleUnfollowUser>(_articleUnfollowUserHandler);
   }
 
   Future<void> _articleGetArticleHandler(
@@ -29,6 +34,80 @@ class ArticleBloc extends Bloc<ArticleEvent, ArticleState> {
       emit(state.copyWith(
         articleStatus: ECommonStatus.loaded,
         article: res,
+      ));
+    } on DioException catch (e) {
+      if (e.response != null) {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.response!.data.toString(),
+        ));
+      } else {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.message,
+        ));
+      }
+    } catch (e) {
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.error,
+        message: e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _articleFollowUserHandler(
+    ArticleFollowUser event,
+    Emitter<ArticleState> emit,
+  ) async {
+    if (state.article?.author?.username == null) return;
+
+    emit(state.copyWith(articleStatus: ECommonStatus.loading));
+    try {
+      var res =
+          await profileRepository.followUser(state.article!.author!.username!);
+
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.loaded,
+        article: state.article?.copyWithAuthor(
+          author: res,
+        ),
+      ));
+    } on DioException catch (e) {
+      if (e.response != null) {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.response!.data.toString(),
+        ));
+      } else {
+        emit(state.copyWith(
+          articleStatus: ECommonStatus.error,
+          message: e.message,
+        ));
+      }
+    } catch (e) {
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.error,
+        message: e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _articleUnfollowUserHandler(
+    ArticleUnfollowUser event,
+    Emitter<ArticleState> emit,
+  ) async {
+    if (state.article?.author?.username == null) return;
+
+    emit(state.copyWith(articleStatus: ECommonStatus.loading));
+    try {
+      var res = await profileRepository
+          .unfollowUser(state.article!.author!.username!);
+
+      emit(state.copyWith(
+        articleStatus: ECommonStatus.loaded,
+        article: state.article?.copyWithAuthor(
+          author: res,
+        ),
       ));
     } on DioException catch (e) {
       if (e.response != null) {

--- a/lib/bloc/article/article_event.dart
+++ b/lib/bloc/article/article_event.dart
@@ -1,3 +1,7 @@
 abstract class ArticleEvent {}
 
 class ArticleGetArticle extends ArticleEvent {}
+
+class ArticleFollowUser extends ArticleEvent {}
+
+class ArticleUnfollowUser extends ArticleEvent {}

--- a/lib/bloc/article/article_event.dart
+++ b/lib/bloc/article/article_event.dart
@@ -5,3 +5,7 @@ class ArticleGetArticle extends ArticleEvent {}
 class ArticleFollowUser extends ArticleEvent {}
 
 class ArticleUnfollowUser extends ArticleEvent {}
+
+class ArticleFav extends ArticleEvent {}
+
+class ArticleUnfav extends ArticleEvent {}

--- a/lib/bloc/profile/profile_cubit.dart
+++ b/lib/bloc/profile/profile_cubit.dart
@@ -40,6 +40,68 @@ class ProfileCubit extends Cubit<ProfileState> {
       ));
     }
   }
+
+  void followUser() async {
+    if (state.profile?.username == null) return;
+
+    emit(state.copyWith(status: ECommonStatus.loading));
+    try {
+      var res = await profileRepository.followUser(state.profile!.username!);
+
+      emit(state.copyWith(
+        status: ECommonStatus.loaded,
+        profile: res,
+      ));
+    } on DioException catch (e) {
+      if (e.response != null) {
+        emit(state.copyWith(
+          status: ECommonStatus.error,
+          message: e.response!.data.toString(),
+        ));
+      } else {
+        emit(state.copyWith(
+          status: ECommonStatus.error,
+          message: e.message,
+        ));
+      }
+    } catch (e) {
+      emit(state.copyWith(
+        status: ECommonStatus.error,
+        message: e.toString(),
+      ));
+    }
+  }
+
+  void unfollowUser() async {
+    if (state.profile?.username == null) return;
+
+    emit(state.copyWith(status: ECommonStatus.loading));
+    try {
+      var res = await profileRepository.unfollowUser(state.profile!.username!);
+
+      emit(state.copyWith(
+        status: ECommonStatus.loaded,
+        profile: res,
+      ));
+    } on DioException catch (e) {
+      if (e.response != null) {
+        emit(state.copyWith(
+          status: ECommonStatus.error,
+          message: e.response!.data.toString(),
+        ));
+      } else {
+        emit(state.copyWith(
+          status: ECommonStatus.error,
+          message: e.message,
+        ));
+      }
+    } catch (e) {
+      emit(state.copyWith(
+        status: ECommonStatus.error,
+        message: e.toString(),
+      ));
+    }
+  }
 }
 
 class ProfileState extends Equatable {

--- a/lib/models/article_model.dart
+++ b/lib/models/article_model.dart
@@ -60,6 +60,22 @@ class ArticleModel extends Equatable {
 
   Map<String, dynamic> toJson() => _$ArticleModelToJson(this);
 
+  ArticleModel copyWithAuthor({
+    ProfileModel? author,
+  }) =>
+      ArticleModel(
+        slug: slug,
+        title: title,
+        description: description,
+        body: body,
+        tagList: tagList,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        favorited: favorited,
+        favoritesCount: favoritesCount,
+        author: author ?? this.author,
+      );
+
   @override
   List<Object?> get props => [
         slug,

--- a/lib/pages/article/article_page.dart
+++ b/lib/pages/article/article_page.dart
@@ -20,6 +20,9 @@ class ArticlePage extends StatelessWidget {
         title: const AppFont('Article'),
       ),
       body: BlocBuilder<ArticleBloc, ArticleState>(
+        buildWhen: (previous, current) =>
+            current.article == null ||
+            current.articleStatus == ECommonStatus.loaded,
         builder: (context, state) {
           if (state.articleStatus == ECommonStatus.init) {
             context.read<ArticleBloc>().add(ArticleGetArticle());

--- a/lib/pages/article/article_page.dart
+++ b/lib/pages/article/article_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:real_world/bloc/article/article_bloc.dart';
 import 'package:real_world/bloc/article/article_event.dart';
 import 'package:real_world/bloc/article/article_state.dart';
+import 'package:real_world/bloc/authentication/auth_bloc.dart';
+import 'package:real_world/bloc/authentication/auth_state.dart';
 import 'package:real_world/common/enum/common_status_enum.dart';
 import 'package:real_world/common/widgets/app_font.dart';
 import 'package:real_world/constants/gaps.dart';
@@ -18,6 +21,49 @@ class ArticlePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const AppFont('Article'),
+        actions: [
+          BlocBuilder<ArticleBloc, ArticleState>(
+            builder: (context, state) => IconButton.outlined(
+              color: Theme.of(context).primaryColor,
+              style: IconButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(Sizes.size5),
+                ),
+              ),
+              onPressed: () {
+                if (context.read<AuthBloc>().state is! AuthAuthenticatedState) {
+                  context.push('/login');
+                  return;
+                }
+
+                if (state.articleStatus == ECommonStatus.loading) return;
+                if (state.article?.favorited == true) {
+                  context.read<ArticleBloc>().add(ArticleUnfav());
+                } else {
+                  context.read<ArticleBloc>().add(ArticleFav());
+                }
+              },
+              icon: Row(
+                children: [
+                  Icon(
+                    state.article?.favorited == true
+                        ? Icons.favorite
+                        : Icons.favorite_border,
+                    size: Sizes.size16,
+                  ),
+                  Gaps.h3,
+                  AppFont(
+                    state.article?.favoritesCount.toString() ?? '0',
+                    style: TextStyle(
+                      color: Theme.of(context).primaryColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Gaps.h10,
+        ],
       ),
       body: BlocBuilder<ArticleBloc, ArticleState>(
         buildWhen: (previous, current) =>

--- a/lib/pages/article/widgets/author_widget.dart
+++ b/lib/pages/article/widgets/author_widget.dart
@@ -31,8 +31,9 @@ class AuthorWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             GestureDetector(
-              onTap: () {
-                context.push('/profile/${author.username}');
+              onTap: () async {
+                await context.push('/profile/${author.username}');
+                context.read<ArticleBloc>().add(ArticleGetArticle());
               },
               child: AppFont(
                 author.username ?? 'N/A',
@@ -52,7 +53,7 @@ class AuthorWidget extends StatelessWidget {
         ),
         BlocBuilder<ArticleBloc, ArticleState>(
           builder: (context, state) => IconButton.outlined(
-            color: Colors.white,
+            color: color ?? Colors.white,
             style: IconButton.styleFrom(
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(Sizes.size5),
@@ -79,8 +80,8 @@ class AuthorWidget extends StatelessWidget {
                   state.article?.author?.following == true
                       ? 'Unfollow'
                       : 'Follow',
-                  style: const TextStyle(
-                    color: Colors.white,
+                  style: TextStyle(
+                    color: color ?? Colors.white,
                   ),
                 ),
               ],

--- a/lib/pages/article/widgets/author_widget.dart
+++ b/lib/pages/article/widgets/author_widget.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:real_world/bloc/article/article_bloc.dart';
 import 'package:real_world/bloc/article/article_event.dart';
 import 'package:real_world/bloc/article/article_state.dart';
+import 'package:real_world/bloc/authentication/auth_bloc.dart';
+import 'package:real_world/bloc/authentication/auth_state.dart';
 import 'package:real_world/common/enum/common_status_enum.dart';
 import 'package:real_world/common/widgets/app_font.dart';
 import 'package:real_world/constants/gaps.dart';
@@ -60,6 +62,11 @@ class AuthorWidget extends StatelessWidget {
               ),
             ),
             onPressed: () {
+              if (context.read<AuthBloc>().state is! AuthAuthenticatedState) {
+                context.push('/login');
+                return;
+              }
+
               if (state.articleStatus == ECommonStatus.loading) return;
               if (state.article?.author?.following == true) {
                 context.read<ArticleBloc>().add(ArticleUnfollowUser());

--- a/lib/pages/article/widgets/author_widget.dart
+++ b/lib/pages/article/widgets/author_widget.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:real_world/bloc/article/article_bloc.dart';
+import 'package:real_world/bloc/article/article_event.dart';
+import 'package:real_world/bloc/article/article_state.dart';
+import 'package:real_world/common/enum/common_status_enum.dart';
 import 'package:real_world/common/widgets/app_font.dart';
+import 'package:real_world/constants/gaps.dart';
 import 'package:real_world/constants/sizes.dart';
 import 'package:real_world/models/profile_model.dart';
 
@@ -18,25 +24,67 @@ class AuthorWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        GestureDetector(
-          onTap: () {
-            context.push('/profile/${author.username}');
-          },
-          child: AppFont(
-            author.username ?? 'N/A',
-            style: TextStyle(
-              color: color ?? Colors.white,
-              fontSize: Sizes.size16,
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GestureDetector(
+              onTap: () {
+                context.push('/profile/${author.username}');
+              },
+              child: AppFont(
+                author.username ?? 'N/A',
+                style: TextStyle(
+                  color: color ?? Colors.white,
+                  fontSize: Sizes.size16,
+                ),
+              ),
             ),
-          ),
+            AppFont(
+              createdAt.toString(),
+              style: TextStyle(
+                color: Colors.grey.shade400,
+              ),
+            ),
+          ],
         ),
-        AppFont(
-          createdAt.toString(),
-          style: TextStyle(
-            color: Colors.grey.shade400,
+        BlocBuilder<ArticleBloc, ArticleState>(
+          builder: (context, state) => IconButton.outlined(
+            color: Colors.white,
+            style: IconButton.styleFrom(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(Sizes.size5),
+              ),
+            ),
+            onPressed: () {
+              if (state.articleStatus == ECommonStatus.loading) return;
+              if (state.article?.author?.following == true) {
+                context.read<ArticleBloc>().add(ArticleUnfollowUser());
+              } else {
+                context.read<ArticleBloc>().add(ArticleFollowUser());
+              }
+            },
+            icon: Row(
+              children: [
+                Icon(
+                  state.article?.author?.following == true
+                      ? Icons.remove
+                      : Icons.add,
+                  size: Sizes.size16,
+                ),
+                Gaps.h3,
+                AppFont(
+                  state.article?.author?.following == true
+                      ? 'Unfollow'
+                      : 'Follow',
+                  style: const TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ],

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -58,15 +58,15 @@ class _HomePageState extends State<HomePage> {
         ],
       ),
       body: BlocConsumer<HomeBloc, HomeState>(
+        listenWhen: (previous, current) =>
+            previous.page != current.page || previous.tag != current.tag,
         listener: (context, state) {
-          if (state.status == ECommonStatus.loaded) {
-            if (_controller.hasClients) {
-              _controller.animateTo(
-                0,
-                duration: const Duration(milliseconds: 500),
-                curve: Curves.easeInOut,
-              );
-            }
+          if (_controller.hasClients) {
+            _controller.animateTo(
+              0,
+              duration: const Duration(milliseconds: 500),
+              curve: Curves.easeInOut,
+            );
           }
         },
         builder: (context, state) {

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -52,6 +52,7 @@ class _HomePageState extends State<HomePage> {
             );
           },
         ),
+        centerTitle: false,
         actions: const [
           AuthActions(),
         ],

--- a/lib/pages/home/widgets/article_container.dart
+++ b/lib/pages/home/widgets/article_container.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:real_world/bloc/home/home_bloc.dart';
+import 'package:real_world/bloc/home/home_event.dart';
 import 'package:real_world/common/widgets/app_font.dart';
 import 'package:real_world/constants/gaps.dart';
 import 'package:real_world/constants/sizes.dart';
@@ -24,8 +27,11 @@ class ArticleContainer extends StatelessWidget {
         shape: const LinearBorder(),
         padding: const EdgeInsets.all(Sizes.size20),
       ),
-      onPressed: () {
-        context.push('/article/${article.slug}');
+      onPressed: () async {
+        await context.push('/article/${article.slug}');
+        context.read<HomeBloc>().add(HomeGetArticles(
+              page: context.read<HomeBloc>().state.page,
+            ));
       },
       child: Container(
         decoration: const BoxDecoration(),
@@ -57,14 +63,15 @@ class ArticleContainer extends StatelessWidget {
                     ),
                   ],
                 ),
-                IconButton.outlined(
-                  style: IconButton.styleFrom(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(Sizes.size5),
+                Container(
+                  padding: const EdgeInsets.all(Sizes.size10),
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: Colors.grey,
                     ),
+                    borderRadius: BorderRadius.circular(Sizes.size5),
                   ),
-                  onPressed: () {},
-                  icon: Row(
+                  child: Row(
                     children: [
                       const Icon(
                         Icons.favorite,

--- a/lib/pages/home/widgets/article_container.dart
+++ b/lib/pages/home/widgets/article_container.dart
@@ -74,7 +74,7 @@ class ArticleContainer extends StatelessWidget {
                       AppFont(article.favoritesCount.toString()),
                     ],
                   ),
-                )
+                ),
               ],
             ),
             Gaps.v10,

--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -21,9 +21,47 @@ class ProfilePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const AppFont('Profile'),
-        actions: const [],
+        centerTitle: true,
+        actions: [
+          BlocBuilder<ProfileCubit, ProfileState>(
+            builder: (context, state) => IconButton.outlined(
+              color: Theme.of(context).primaryColor,
+              style: IconButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(Sizes.size5),
+                ),
+              ),
+              onPressed: () {
+                if (state.status == ECommonStatus.loading) return;
+                if (state.profile?.following == true) {
+                  context.read<ProfileCubit>().unfollowUser();
+                } else {
+                  context.read<ProfileCubit>().followUser();
+                }
+              },
+              icon: Row(
+                children: [
+                  Icon(
+                    state.profile?.following == true ? Icons.remove : Icons.add,
+                    size: Sizes.size16,
+                  ),
+                  Gaps.h3,
+                  AppFont(
+                    state.profile?.following == true ? 'Unfollow' : 'Follow',
+                    style: TextStyle(
+                      color: Theme.of(context).primaryColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Gaps.h10,
+        ],
       ),
       body: BlocBuilder<ProfileCubit, ProfileState>(
+        buildWhen: (previous, current) =>
+            current.profile == null || current.status == ECommonStatus.loaded,
         builder: (context, state) {
           if (state.status == ECommonStatus.init) {
             context.read<ProfileCubit>().getProfile(username);

--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:real_world/bloc/authentication/auth_bloc.dart';
+import 'package:real_world/bloc/authentication/auth_state.dart';
 import 'package:real_world/bloc/profile/profile_cubit.dart';
 import 'package:real_world/common/enum/common_status_enum.dart';
 import 'package:real_world/common/widgets/app_font.dart';
@@ -32,6 +35,11 @@ class ProfilePage extends StatelessWidget {
                 ),
               ),
               onPressed: () {
+                if (context.read<AuthBloc>().state is! AuthAuthenticatedState) {
+                  context.push('/login');
+                  return;
+                }
+
                 if (state.status == ECommonStatus.loading) return;
                 if (state.profile?.following == true) {
                   context.read<ProfileCubit>().unfollowUser();

--- a/lib/pages/realworld_router.dart
+++ b/lib/pages/realworld_router.dart
@@ -92,6 +92,7 @@ class _RealWorldRouterState extends State<RealWorldRouter> {
             create: (context) => ArticleBloc(
               slug: state.pathParameters['slug']!,
               articleRepository: context.read<ArticleRepository>(),
+              profileRepository: context.read<ProfileRepository>(),
             ),
             child: const ArticlePage(),
           ),

--- a/lib/repository/article_repository.dart
+++ b/lib/repository/article_repository.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:real_world/interceptors/auth_interceptor.dart';
 import 'package:real_world/interceptors/no_auth_interceptor.dart';
 import 'package:real_world/models/article_model.dart';
 
@@ -51,6 +52,28 @@ class ArticleRepository {
     dio.interceptors.add(NoAuthInterceptor());
 
     var res = await dio.get('/api/articles/$slug');
+
+    return ArticleModel.fromJson(res.data['article']);
+  }
+
+  Future<ArticleModel> favArticle({
+    required String slug,
+  }) async {
+    Dio dio = Dio();
+    dio.interceptors.add(AuthInterceptor());
+
+    var res = await dio.post('/api/articles/$slug/favorite');
+
+    return ArticleModel.fromJson(res.data['article']);
+  }
+
+  Future<ArticleModel> unfavArticle({
+    required String slug,
+  }) async {
+    Dio dio = Dio();
+    dio.interceptors.add(AuthInterceptor());
+
+    var res = await dio.delete('/api/articles/$slug/favorite');
 
     return ArticleModel.fromJson(res.data['article']);
   }

--- a/lib/repository/profile_repository.dart
+++ b/lib/repository/profile_repository.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:real_world/interceptors/auth_interceptor.dart';
 import 'package:real_world/interceptors/no_auth_interceptor.dart';
 import 'package:real_world/models/profile_model.dart';
 
@@ -8,6 +9,24 @@ class ProfileRepository {
     dio.interceptors.add(NoAuthInterceptor());
 
     var res = await dio.get('/api/profiles/$username');
+
+    return ProfileModel.fromJson(res.data['profile']);
+  }
+
+  Future<ProfileModel> followUser(String username) async {
+    Dio dio = Dio();
+    dio.interceptors.add(AuthInterceptor());
+
+    var res = await dio.post('/api/profiles/$username/follow');
+
+    return ProfileModel.fromJson(res.data['profile']);
+  }
+
+  Future<ProfileModel> unfollowUser(String username) async {
+    Dio dio = Dio();
+    dio.interceptors.add(AuthInterceptor());
+
+    var res = await dio.delete('/api/profiles/$username/follow');
 
     return ProfileModel.fromJson(res.data['profile']);
   }


### PR DESCRIPTION
유저에 대한 팔로우 / 언팔로우 기능,
포스트에 대한 좋아요 / 좋아요 취소 기능 구현 완료했습니다.

또한, 각 기능은 `AuthBloc`의 `AuthAuthenticatedState` 상태일 경우에만 동작하며, 
그 외의 경우에 클릭하는 경우 로그인 페이지로 자동으로 이동하게끔 구현하였습니다.

추가로, 팔로우, 좋아요로 인해 상태가 업데이트가 되어야 하기 때문에, context.pop()을 하게될 경우,
필요한 페이지는 데이터를 다시 로드하는 기능 또한 구현하였습니다.